### PR TITLE
Catch samba command error

### DIFF
--- a/tf2md3_flash
+++ b/tf2md3_flash
@@ -90,8 +90,13 @@ nvm 4
 EOD
 
 samba -i ${device} --source=/tmp/.samba_cmd.tmp
+ret=$?
 
 rm /tmp/.samba_cmd.tmp
+if [[ $ret -ne 0 ]]; then
+  echo "Failed to write firmware ($ret)" 1>&2
+  exit 1
+fi
 
 if [ ${reset} = "yes" ]; then
   echo "Resetting MCU..."
@@ -99,6 +104,11 @@ if [ ${reset} = "yes" ]; then
 reset
 EOD
   samba -i ${device} --source=/tmp/.samba_reset.tmp
+  ret=$?
 
   rm /tmp/.samba_reset.tmp
+  if [[ $ret -ne 0 ]]; then
+    echo "Failed to reset MCU ($ret)" 1>&2
+    exit 1
+  fi
 fi

--- a/tf2md3_flash
+++ b/tf2md3_flash
@@ -91,8 +91,8 @@ EOD
 
 samba -i ${device} --source=/tmp/.samba_cmd.tmp
 ret=$?
-
 rm /tmp/.samba_cmd.tmp
+
 if [[ $ret -ne 0 ]]; then
   echo "Failed to write firmware ($ret)" 1>&2
   exit 1
@@ -105,8 +105,8 @@ reset
 EOD
   samba -i ${device} --source=/tmp/.samba_reset.tmp
   ret=$?
-
   rm /tmp/.samba_reset.tmp
+
   if [[ $ret -ne 0 ]]; then
     echo "Failed to reset MCU ($ret)" 1>&2
     exit 1


### PR DESCRIPTION
The script returned 0 even when the samba command to write the firmware failed.